### PR TITLE
fix(types): export type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "exports": {
         "./package.json": "./package.json",
         ".": {
+            "types": "./dist/index.d.ts",
             "require": "./dist/index.cjs",
             "import": "./dist/index.mjs"
         }


### PR DESCRIPTION
```
Could not find a declaration file for module 'locter'. 'xxx/node_modules/locter/dist/index.mjs' implicitly has an 'any' type.
  There are types at 'xxx/node_modules/locter/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'locter' library may need to update its package.json or typings.
```