### PR TITLE
feat(loader): allow injecting a custom module load/loadSync (closes #826)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -158,6 +158,52 @@ registerLoader(['.ext'], {
 })
 ```
 
+### Runtime environments
+
+Locter ships with two runtime detection helpers:
+
+- `isJestRuntimeEnvironment()` — true when running under Jest. Built-in: the
+  `ModuleLoader` falls back to `require()` under Jest to avoid a known
+  segmentation fault ([nodejs/node#35889](https://github.com/nodejs/node/issues/35889)).
+- `isVitestRuntimeEnvironment()` — true when running under Vitest (checks
+  `process.env.VITEST === 'true'`).
+
+#### Using locter with Vitest
+
+Locter's built-in `await import(id)` runs inside `node_modules/locter` and
+therefore bypasses Vitest's `vite-node` module graph by default. For most use
+cases this is fine, but it produces **duplicate module instances** when test
+code statically imports a module and locter dynamically loads the same module
+(or a transitive dependency of it). This breaks class identity for libraries
+that rely on it (e.g. TypeORM entity metadata).
+
+Use `setModuleLoader` to inject an `import` call from user space so Vitest can
+rewrite it:
+
+```typescript
+// vitest setup file
+import { setModuleLoader } from 'locter';
+
+setModuleLoader({
+    load: (id) => import(id),
+});
+```
+
+Alternatively, the same effect can be achieved by inlining locter in
+`vitest.config.ts`:
+
+```typescript
+export default defineConfig({
+    test: {
+        server: {
+            deps: {
+                inline: [/locter/],
+            },
+        },
+    },
+});
+```
+
 
 ## License
 

--- a/src/loader/built-in/module/module.ts
+++ b/src/loader/built-in/module/module.ts
@@ -24,7 +24,12 @@ import {
     isTypeScriptError,
 } from '../../../utils';
 import type { Loader } from '../../type';
-import type { ModuleLoadOptions } from './type';
+import type {
+    ModuleLoadFn,
+    ModuleLoadOptions,
+    ModuleLoadSyncFn,
+    ModuleLoaderOptions,
+} from './type';
 import { toModuleRecord } from './utils';
 
 const require = createRequire(import.meta.url);
@@ -34,10 +39,25 @@ type Jiti = ReturnType<typeof createJiti>;
 export class ModuleLoader implements Loader {
     protected instance : Jiti;
 
-    constructor() {
+    protected loadFn?: ModuleLoadFn;
+
+    protected loadSyncFn?: ModuleLoadSyncFn;
+
+    constructor(options: ModuleLoaderOptions = {}) {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         this.instance = createJiti(undefined, { extensions: ['.js', '.mjs', '.mts', '.cjs', '.cts', '.ts'] });
+        this.loadFn = options.load;
+        this.loadSyncFn = options.loadSync;
+    }
+
+    configure(options: ModuleLoaderOptions) : void {
+        if ('load' in options) {
+            this.loadFn = options.load;
+        }
+        if ('loadSync' in options) {
+            this.loadSyncFn = options.loadSync;
+        }
     }
 
     async execute(input: string) {
@@ -95,6 +115,10 @@ export class ModuleLoader implements Loader {
         const id = this.build(data, options);
 
         try {
+            if (this.loadFn) {
+                return await this.loadFn(id);
+            }
+
             // segmentation fault
             // issue: https://github.com/nodejs/node/issues/35889
             if (isJestRuntimeEnvironment()) {
@@ -140,6 +164,10 @@ export class ModuleLoader implements Loader {
         const id = this.build(data, options);
 
         try {
+            if (this.loadSyncFn) {
+                return this.loadSyncFn(id);
+            }
+
             return require(id);
         } catch (e) {
             /* istanbul ignore next */

--- a/src/loader/built-in/module/type.ts
+++ b/src/loader/built-in/module/type.ts
@@ -15,3 +15,23 @@ export type ModuleExport = {
 export type ModuleLoadOptions = {
     withFilePrefix?: boolean
 };
+
+export type ModuleLoadFn = (id: string) => unknown | Promise<unknown>;
+
+export type ModuleLoadSyncFn = (id: string) => unknown;
+
+export type ModuleLoaderOptions = {
+    /**
+     * Custom asynchronous module loader. When set, this replaces the
+     * built-in `await import(id)` call. Useful for test runners (e.g. Vitest)
+     * where dynamic imports inside `node_modules/locter` would otherwise
+     * escape the runner's module graph — defining this in user space lets
+     * the runner rewrite the `import()`.
+     */
+    load?: ModuleLoadFn,
+    /**
+     * Custom synchronous module loader. When set, this replaces the built-in
+     * `require(id)` call.
+     */
+    loadSync?: ModuleLoadSyncFn
+};

--- a/src/loader/helpers.ts
+++ b/src/loader/helpers.ts
@@ -7,6 +7,9 @@
 
 import { buildFilePath } from '../locator';
 import type { LocatorInfo } from '../locator';
+import type { ModuleLoader } from './built-in/module';
+import type { ModuleLoaderOptions } from './built-in/module/type';
+import { LoaderId } from './constants';
 import { useLoader } from './singleton';
 import type { Loader, Rule } from './type';
 
@@ -39,4 +42,28 @@ export function loadSync(input: LocatorInfo | string) : any {
     }
 
     return manager.executeSync(buildFilePath(input));
+}
+
+/**
+ * Override the built-in module loader's `import` / `require` calls.
+ *
+ * Useful for test runners (e.g. Vitest) where the dynamic `import()` inside
+ * `node_modules/locter` would bypass the runner's module graph. Calling this
+ * from user code (e.g. a Vitest setup file) lets the runner rewrite the
+ * `import()` so loaded modules share identity with statically imported ones.
+ *
+ * @example
+ * ```ts
+ * // vitest setup file
+ * import { setModuleLoader } from 'locter';
+ *
+ * setModuleLoader({
+ *     load: (id) => import(id),
+ * });
+ * ```
+ */
+export function setModuleLoader(options: ModuleLoaderOptions) : void {
+    const manager = useLoader();
+    const loader = manager.resolve(LoaderId.MODULE) as ModuleLoader;
+    loader.configure(options);
 }

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -10,6 +10,11 @@ export function isJestRuntimeEnvironment() : boolean {
         process.env.JEST_WORKER_ID !== undefined;
 }
 
+export function isVitestRuntimeEnvironment() : boolean {
+    return typeof process !== 'undefined' &&
+        process.env.VITEST === 'true';
+}
+
 export function isTsNodeRuntimeEnvironment(): boolean {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore

--- a/test/unit/loader/module.spec.ts
+++ b/test/unit/loader/module.spec.ts
@@ -8,9 +8,11 @@
 import { describe, expect, it } from 'vitest';
 import {
     LoaderManager,
+    ModuleLoader,
     getModuleExport,
     load,
     loadSync,
+    setModuleLoader,
 } from '../../../src';
 import { LoaderId } from '../../../src/loader/constants';
 
@@ -78,5 +80,102 @@ describe('src/loader/**', () => {
         const manager = new LoaderManager();
         const loader = manager.findLoader('foo');
         expect(loader).toEqual(LoaderId.MODULE);
+    });
+
+    it('should use injected load / loadSync functions', async () => {
+        const calls: { id: string, sync: boolean }[] = [];
+        const moduleLoader = new ModuleLoader({
+            load: (id) => {
+                calls.push({ id, sync: false });
+                return { injected: 'async', id };
+            },
+            loadSync: (id) => {
+                calls.push({ id, sync: true });
+                return { injected: 'sync', id };
+            },
+        });
+
+        const asyncResult = await moduleLoader.load('virtual-module-id');
+        expect(calls).toEqual([{ id: 'virtual-module-id', sync: false }]);
+        expect(asyncResult).toEqual({ injected: 'async', id: 'virtual-module-id' });
+
+        const syncResult = moduleLoader.loadSync('virtual-module-id');
+        expect(calls).toEqual([
+            { id: 'virtual-module-id', sync: false },
+            { id: 'virtual-module-id', sync: true },
+        ]);
+        expect(syncResult).toEqual({ injected: 'sync', id: 'virtual-module-id' });
+    });
+
+    it('should reconfigure module loader at runtime', async () => {
+        const moduleLoader = new ModuleLoader();
+        let called = false;
+        moduleLoader.configure({
+            load: (id) => {
+                called = true;
+                return { id };
+            },
+        });
+
+        const result = await moduleLoader.load('any-id');
+        expect(called).toBe(true);
+        expect(result).toEqual({ id: 'any-id' });
+    });
+
+    it('should clear configured loader functions via configure({ load: undefined })', async () => {
+        const moduleLoader = new ModuleLoader({ load: () => ({ source: 'injected' }) });
+
+        let result = await moduleLoader.load('yaml');
+        expect(result).toEqual({ source: 'injected' });
+
+        moduleLoader.configure({ load: undefined });
+
+        result = await moduleLoader.load('yaml');
+        expect(result).toBeDefined();
+        expect((result as any).parse).toBeDefined();
+    });
+
+    it('should override the singleton module loader via setModuleLoader', async () => {
+        const seenAsync: string[] = [];
+        const seenSync: string[] = [];
+
+        setModuleLoader({
+            load: (id) => {
+                seenAsync.push(id);
+                return {
+                    __esModule: true, 
+                    from: 'setModuleLoader-async', 
+                    id, 
+                };
+            },
+            loadSync: (id) => {
+                seenSync.push(id);
+                return {
+                    __esModule: true, 
+                    from: 'setModuleLoader-sync', 
+                    id, 
+                };
+            },
+        });
+
+        try {
+            const asyncResult = await load('yaml');
+            expect(seenAsync).toEqual(['yaml']);
+            expect(asyncResult.from).toEqual('setModuleLoader-async');
+            expect(asyncResult.id).toEqual('yaml');
+
+            const syncResult = loadSync('yaml');
+            expect(seenSync).toEqual(['yaml']);
+            expect(syncResult.from).toEqual('setModuleLoader-sync');
+            expect(syncResult.id).toEqual('yaml');
+        } finally {
+            // restore singleton so we don't leak state to later tests in this file
+            setModuleLoader({ load: undefined, loadSync: undefined });
+        }
+
+        // verify the singleton is fully restored
+        const restored = await load('yaml');
+        expect(restored).toBeDefined();
+        expect(restored.parse).toBeDefined();
     });
 });

--- a/test/unit/utils.spec.ts
+++ b/test/unit/utils.spec.ts
@@ -6,7 +6,11 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { isJestRuntimeEnvironment, removeFileNameExtension } from '../../src';
+import {
+    isJestRuntimeEnvironment,
+    isVitestRuntimeEnvironment,
+    removeFileNameExtension,
+} from '../../src';
 
 describe('src/utils/*.ts', () => {
     it('should remove file name extension', () => {
@@ -26,5 +30,9 @@ describe('src/utils/*.ts', () => {
     it('should detect jest runtime environment', () => {
         // Running under vitest, so this must be false.
         expect(isJestRuntimeEnvironment()).toEqual(false);
+    });
+
+    it('should detect vitest runtime environment', () => {
+        expect(isVitestRuntimeEnvironment()).toEqual(true);
     });
 });


### PR DESCRIPTION
## Summary

- Adds `setModuleLoader({ load?, loadSync? })` so callers can inject the
  module-loading functions used internally by `ModuleLoader`. The built-in
  `await import(id)` runs inside `node_modules/locter` and therefore
  escapes Vitest's `vite-node` module graph (`node_modules` packages are
  treated as externals by default), producing duplicate module instances
  for anything statically imported by the test and dynamically loaded by
  locter. Letting users pass `(id) => import(id)` from a setup file puts
  the `import()` call in user space, where the runner can rewrite it —
  fixing class-identity issues (e.g. TypeORM `EntityMetadataNotFoundError`
  in `typeorm-extension` seeders).
- Adds `isVitestRuntimeEnvironment()` runtime helper alongside the
  existing `isJestRuntimeEnvironment()`.
- README: new "Runtime environments" section documenting both the
  `setModuleLoader` workaround and the alternative `server.deps.inline`
  approach.

Closes #826.

## Test plan

- [x] `npm run build` (typecheck + bundle)
- [x] `npm run lint`
- [x] `npm test` — 43 tests pass, including new coverage for:
  - `ModuleLoader` constructor option (`{ load, loadSync }`)
  - `ModuleLoader.configure(...)` reassignment and clearing
    (`configure({ load: undefined })`)
  - top-level `setModuleLoader(...)` routing through the singleton, with
    cleanup verifying the singleton restores to the built-in behavior
  - `isVitestRuntimeEnvironment()` returns `true` under Vitest

## Notes

- No breaking changes — both new options are purely additive and the
  built-in `import()` / `require()` paths are unchanged when nothing is
  injected.
- Did not implement the stretch option (auto-bridging to vite-node via
  `createServer` + `ssrLoadModule`) — too invasive and the issue itself
  flags it as probably not worth the cost.