### PR TITLE
feat(locator)!: rename LocatorInfo.path to directory and add filePath

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -50,8 +50,8 @@ import { locateMany } from 'locter';
     console.log(files);
     /*
     [
-        { directory: '/cwd/files', name: 'example', extension: '.js', filePath: '/cwd/files/example.js' },
-        { directory: '/cwd/files', name: 'example', extension: '.ts', filePath: '/cwd/files/example.ts' }
+        { directory: '/cwd/files', name: 'example', extension: '.js', path: '/cwd/files/example.js' },
+        { directory: '/cwd/files', name: 'example', extension: '.ts', path: '/cwd/files/example.ts' }
     ]
      */
 
@@ -62,9 +62,9 @@ import { locateMany } from 'locter';
     console.log(files);
     /*
     [
-        { directory: '/cwd/files', name: 'example', extension: '.js', filePath: '/cwd/files/example.js' },
-        { directory: '/cwd/files', name: 'example', extension: '.ts', filePath: '/cwd/files/example.ts' },
-        { directory: '/cwd/files', name: 'example-long', extension: '.ts', filePath: '/cwd/files/example-long.ts' }
+        { directory: '/cwd/files', name: 'example', extension: '.js', path: '/cwd/files/example.js' },
+        { directory: '/cwd/files', name: 'example', extension: '.ts', path: '/cwd/files/example.ts' },
+        { directory: '/cwd/files', name: 'example-long', extension: '.ts', path: '/cwd/files/example-long.ts' }
     ]
      */
 })
@@ -86,7 +86,7 @@ import { locate } from 'locter';
 
     console.log(file);
     /*
-    { directory: '/cwd/files', name: 'example', extension: '.js', filePath: '/cwd/files/example.js' }
+    { directory: '/cwd/files', name: 'example', extension: '.js', path: '/cwd/files/example.js' }
      */
 })
 ```

--- a/README.MD
+++ b/README.MD
@@ -50,8 +50,8 @@ import { locateMany } from 'locter';
     console.log(files);
     /*
     [
-        { path: 'files', name: 'example', extension: '.js'},
-        { path: 'files', name: 'example', extension: '.ts'}
+        { directory: '/cwd/files', name: 'example', extension: '.js', filePath: '/cwd/files/example.js' },
+        { directory: '/cwd/files', name: 'example', extension: '.ts', filePath: '/cwd/files/example.ts' }
     ]
      */
 
@@ -62,9 +62,9 @@ import { locateMany } from 'locter';
     console.log(files);
     /*
     [
-        { path: 'files', name: 'example', extension: '.js'},
-        { path: 'files', name: 'example', extension: '.ts'},
-        { path: 'files', name: 'example-long', extension: '.ts'},
+        { directory: '/cwd/files', name: 'example', extension: '.js', filePath: '/cwd/files/example.js' },
+        { directory: '/cwd/files', name: 'example', extension: '.ts', filePath: '/cwd/files/example.ts' },
+        { directory: '/cwd/files', name: 'example-long', extension: '.ts', filePath: '/cwd/files/example-long.ts' }
     ]
      */
 })
@@ -86,7 +86,7 @@ import { locate } from 'locter';
 
     console.log(file);
     /*
-    { path: 'files', name: 'example', extension: '.js'}
+    { directory: '/cwd/files', name: 'example', extension: '.js', filePath: '/cwd/files/example.js' }
      */
 })
 ```

--- a/src/locator/types.ts
+++ b/src/locator/types.ts
@@ -6,9 +6,10 @@
  */
 
 export type LocatorInfo = {
-    path: string,
+    directory: string,
     name: string,
-    extension?: string
+    extension?: string,
+    filePath: string,
 };
 
 export type LocatorOptions = {

--- a/src/locator/types.ts
+++ b/src/locator/types.ts
@@ -9,7 +9,7 @@ export type LocatorInfo = {
     directory: string,
     name: string,
     extension?: string,
-    filePath: string,
+    path: string,
 };
 
 export type LocatorOptions = {

--- a/src/locator/utils.ts
+++ b/src/locator/utils.ts
@@ -72,7 +72,7 @@ export function pathToLocatorInfo(
         directory,
         name: info.name,
         extension,
-        filePath,
+        path: filePath,
     };
 }
 
@@ -82,7 +82,8 @@ export function isLocatorInfo(
     return isObject(input) &&
         typeof input.directory === 'string' &&
         typeof input.name === 'string' &&
-        typeof input.filePath === 'string';
+        (typeof input.extension === 'undefined' || typeof input.extension === 'string') &&
+        typeof input.path === 'string';
 }
 
 export function buildFilePath(input: LocatorInfo | string) {
@@ -90,7 +91,7 @@ export function buildFilePath(input: LocatorInfo | string) {
         return input;
     }
 
-    return input.filePath;
+    return input.path;
 }
 
 export function buildFilePathWithoutExtension(input: LocatorInfo | string) {

--- a/src/locator/utils.ts
+++ b/src/locator/utils.ts
@@ -62,13 +62,17 @@ export function pathToLocatorInfo(
     }
 
     const info = path.parse(input);
+    const directory = info.dir.split('/').join(path.sep);
+    const extension = info.ext ? info.ext : undefined;
+    const filePath = extension ?
+        path.join(directory, info.name) + extension :
+        path.join(directory, info.name);
 
     return {
-        path: info.dir.split('/').join(path.sep),
+        directory,
         name: info.name,
-        extension: info.ext ?
-            info.ext :
-            undefined,
+        extension,
+        filePath,
     };
 }
 
@@ -76,9 +80,9 @@ export function isLocatorInfo(
     input: unknown,
 ) : input is LocatorInfo {
     return isObject(input) &&
-        typeof input.path === 'string' &&
+        typeof input.directory === 'string' &&
         typeof input.name === 'string' &&
-        typeof input.extension === 'string';
+        typeof input.filePath === 'string';
 }
 
 export function buildFilePath(input: LocatorInfo | string) {
@@ -86,11 +90,7 @@ export function buildFilePath(input: LocatorInfo | string) {
         return input;
     }
 
-    if (input.extension) {
-        return path.join(input.path, input.name) + input.extension;
-    }
-
-    return path.join(input.path, input.name);
+    return input.filePath;
 }
 
 export function buildFilePathWithoutExtension(input: LocatorInfo | string) {
@@ -102,5 +102,5 @@ export function buildFilePathWithoutExtension(input: LocatorInfo | string) {
         info = input;
     }
 
-    return path.join(info.path, info.name);
+    return path.join(info.directory, info.name);
 }

--- a/test/unit/locator.spec.ts
+++ b/test/unit/locator.spec.ts
@@ -58,31 +58,35 @@ describe('src/locator.ts', () => {
         let locatorInfo = await locate(['file.[cf]js'], { path: [basePath] });
         expect(locatorInfo).toBeDefined();
         expect(locatorInfo).toEqual({
-            path: basePath,
+            directory: basePath,
             name: 'file',
             extension: '.cjs',
+            filePath: path.join(basePath, 'file.cjs'),
         } as LocatorInfo);
 
         locatorInfo = locateSync(['file.[mf]js'], { path: [basePath] });
         expect(locatorInfo).toBeDefined();
         expect(locatorInfo).toEqual({
-            path: basePath,
+            directory: basePath,
             name: 'file',
             extension: '.mjs',
+            filePath: path.join(basePath, 'file.mjs'),
         } as LocatorInfo);
     });
 
     it('should locate .[cm]ts files', async () => {
         const files : LocatorInfo[] = [
             {
-                path: basePath,
+                directory: basePath,
                 name: 'file',
                 extension: '.cts',
+                filePath: path.join(basePath, 'file.cts'),
             },
             {
-                path: basePath,
+                directory: basePath,
                 name: 'file',
                 extension: '.mts',
+                filePath: path.join(basePath, 'file.mts'),
             },
         ];
         let locatorInfo = await locateMany(['file.[cm]ts'], { path: [basePath] });
@@ -98,17 +102,19 @@ describe('src/locator.ts', () => {
         let locatorInfo = await locate('file.json', { path: [basePath] });
         expect(locatorInfo).toBeDefined();
         expect(locatorInfo).toEqual({
-            path: basePath,
+            directory: basePath,
             name: 'file',
             extension: '.json',
+            filePath: path.join(basePath, 'file.json'),
         } as LocatorInfo);
 
         locatorInfo = locateSync('file.json', { path: [basePath] });
         expect(locatorInfo).toBeDefined();
         expect(locatorInfo).toEqual({
-            path: basePath,
+            directory: basePath,
             name: 'file',
             extension: '.json',
+            filePath: path.join(basePath, 'file.json'),
         } as LocatorInfo);
     });
 

--- a/test/unit/locator.spec.ts
+++ b/test/unit/locator.spec.ts
@@ -61,7 +61,7 @@ describe('src/locator.ts', () => {
             directory: basePath,
             name: 'file',
             extension: '.cjs',
-            filePath: path.join(basePath, 'file.cjs'),
+            path: path.join(basePath, 'file.cjs'),
         } as LocatorInfo);
 
         locatorInfo = locateSync(['file.[mf]js'], { path: [basePath] });
@@ -70,7 +70,7 @@ describe('src/locator.ts', () => {
             directory: basePath,
             name: 'file',
             extension: '.mjs',
-            filePath: path.join(basePath, 'file.mjs'),
+            path: path.join(basePath, 'file.mjs'),
         } as LocatorInfo);
     });
 
@@ -80,13 +80,13 @@ describe('src/locator.ts', () => {
                 directory: basePath,
                 name: 'file',
                 extension: '.cts',
-                filePath: path.join(basePath, 'file.cts'),
+                path: path.join(basePath, 'file.cts'),
             },
             {
                 directory: basePath,
                 name: 'file',
                 extension: '.mts',
-                filePath: path.join(basePath, 'file.mts'),
+                path: path.join(basePath, 'file.mts'),
             },
         ];
         let locatorInfo = await locateMany(['file.[cm]ts'], { path: [basePath] });
@@ -105,7 +105,7 @@ describe('src/locator.ts', () => {
             directory: basePath,
             name: 'file',
             extension: '.json',
-            filePath: path.join(basePath, 'file.json'),
+            path: path.join(basePath, 'file.json'),
         } as LocatorInfo);
 
         locatorInfo = locateSync('file.json', { path: [basePath] });
@@ -114,7 +114,7 @@ describe('src/locator.ts', () => {
             directory: basePath,
             name: 'file',
             extension: '.json',
-            filePath: path.join(basePath, 'file.json'),
+            path: path.join(basePath, 'file.json'),
         } as LocatorInfo);
     });
 

--- a/test/unit/utils.spec.ts
+++ b/test/unit/utils.spec.ts
@@ -5,10 +5,13 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
     isJestRuntimeEnvironment,
+    isLocatorInfo,
     isVitestRuntimeEnvironment,
+    pathToLocatorInfo,
     removeFileNameExtension,
 } from '../../src';
 
@@ -34,5 +37,27 @@ describe('src/utils/*.ts', () => {
 
     it('should detect vitest runtime environment', () => {
         expect(isVitestRuntimeEnvironment()).toEqual(true);
+    });
+
+    it('should build LocatorInfo for an extensionless path', () => {
+        const filePath = path.resolve('/repo/Makefile');
+        const info = pathToLocatorInfo(filePath);
+
+        expect(info).toEqual({
+            directory: path.resolve('/repo'),
+            name: 'Makefile',
+            extension: undefined,
+            path: filePath,
+        });
+        expect(isLocatorInfo(info)).toBe(true);
+    });
+
+    it('should reject objects with non-string extension', () => {
+        expect(isLocatorInfo({
+            directory: '/repo',
+            name: 'file',
+            extension: 123,
+            path: '/repo/file',
+        })).toBe(false);
     });
 });


### PR DESCRIPTION
## Summary

- Renames `LocatorInfo.path` → `LocatorInfo.directory` (it always was the containing directory, not the file path).
- Adds `LocatorInfo.filePath` — the full path to the file, ready to pass to `load()` / `fs`.
- Simplifies `buildFilePath(info)` to return `info.filePath` directly.
- `isLocatorInfo` now validates the new shape and correctly accepts extensionless entries (previously required `extension: string` despite the type marking it optional).

Closes #822.

## Why

`LocatorInfo.path` invited the assumption that `load(info.path)` would work, but it returned the containing directory, so the call silently failed. Renaming makes the intent obvious and adding `filePath` makes the right thing the obvious thing.

## Breaking changes

- `LocatorInfo.path` is removed. Migrate:
  - `info.path` (old containing-directory semantics) → `info.directory`
  - `buildFilePath(info)` or any computed full path → `info.filePath`

## Test plan

- [x] `npm run lint`
- [x] `npm run build:types`
- [x] `npm test` (43 tests passing)
- [ ] Smoke-check against a downstream consumer (e.g. `@trapi/cli`) after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Locator results now include full file metadata: directory, name, optional extension, and an absolute file path.

* **Documentation**
  * Usage examples updated to show the expanded result shape with directory and absolute path values.

* **Tests**
  * Test expectations updated to assert the new metadata shape and resolved absolute paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/locter/pull/832?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->