### PR TITLE
feat(locator): add `locateUp` for parent-directory walk discovery

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -93,6 +93,30 @@ import { locate } from 'locter';
 
 A synchronous variant is also available: `locateSync`
 
+**Walking up**
+
+`locateUp` walks from a starting directory toward the filesystem root and returns the first match (useful for discovering config files at the repo root from any sub-directory):
+
+```typescript
+import { locateUp } from 'locter';
+
+(async () => {
+    const info = await locateUp('trapi.config.{ts,mts,cts,mjs,cjs,js,json}', {
+        cwd: process.cwd(),
+    });
+
+    console.log(info);
+    /*
+    { directory: '/repo', name: 'trapi.config', extension: '.ts', path: '/repo/trapi.config.ts' }
+    or `undefined` if nothing matched
+     */
+})
+```
+
+Pass `stopAt: '/repo'` to cap the walk at a known ceiling — inclusive, so the ceiling directory itself is still searched.
+
+A synchronous variant `locateUpSync` is also available.
+
 **Options**
 
 `locate` / `locateMany` (and their sync variants) accept an options object:
@@ -104,6 +128,8 @@ A synchronous variant is also available: `locateSync`
 | `onlyFiles`       | `boolean`               | `true`          | Match files only                                       |
 | `onlyDirectories` | `boolean`               | `false`         | Match directories only                                 |
 | `dot`             | `boolean`               | `false`         | Match dotfiles (e.g. `.env`, `.npmrc`) for wildcard patterns |
+
+`locateUp` / `locateUpSync` take the same options except `cwd` must be a single `string`, and additionally accept `stopAt?: string` (inclusive ceiling for the walk).
 
 ### Loader
 

--- a/src/locator/index.ts
+++ b/src/locator/index.ts
@@ -8,4 +8,5 @@
 export * from './async';
 export * from './sync';
 export * from './types';
+export * from './up';
 export * from './utils';

--- a/src/locator/up.ts
+++ b/src/locator/up.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import path from 'node:path';
+import { locate } from './async';
+import { locateSync } from './sync';
+import type { LocatorInfo, LocatorOptionsInput } from './types';
+
+export type LocatorUpOptionsInput = Omit<LocatorOptionsInput, 'cwd'> & {
+    cwd?: string,
+    stopAt?: string,
+};
+
+type WalkStep = {
+    current: string,
+    stopAt: string,
+    baseOptions: Omit<LocatorOptionsInput, 'cwd'>,
+};
+
+function startWalk(options: LocatorUpOptionsInput) : WalkStep {
+    const current = path.resolve(options.cwd ?? process.cwd());
+    const stopAt = options.stopAt ?
+        path.resolve(options.stopAt) :
+        path.parse(current).root;
+
+    const baseOptions: Omit<LocatorOptionsInput, 'cwd'> = {
+        ignore: options.ignore,
+        onlyFiles: options.onlyFiles,
+        onlyDirectories: options.onlyDirectories,
+        dot: options.dot,
+    };
+
+    return {
+        current,
+        stopAt,
+        baseOptions,
+    };
+}
+
+function nextDirectory(current: string, stopAt: string) : string | undefined {
+    if (current === stopAt) {
+        return undefined;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+        return undefined;
+    }
+
+    return parent;
+}
+
+export async function locateUp(
+    pattern: string | string[],
+    options: LocatorUpOptionsInput = {},
+) : Promise<LocatorInfo | undefined> {
+    let walk = startWalk(options);
+
+    while (true) {
+        const found = await locate(pattern, { ...walk.baseOptions, cwd: walk.current });
+        if (found) {
+            return found;
+        }
+
+        const next = nextDirectory(walk.current, walk.stopAt);
+        if (!next) {
+            return undefined;
+        }
+
+        walk = { ...walk, current: next };
+    }
+}
+
+export function locateUpSync(
+    pattern: string | string[],
+    options: LocatorUpOptionsInput = {},
+) : LocatorInfo | undefined {
+    let walk = startWalk(options);
+
+    while (true) {
+        const found = locateSync(pattern, { ...walk.baseOptions, cwd: walk.current });
+        if (found) {
+            return found;
+        }
+
+        const next = nextDirectory(walk.current, walk.stopAt);
+        if (!next) {
+            return undefined;
+        }
+
+        walk = { ...walk, current: next };
+    }
+}

--- a/src/locator/up.ts
+++ b/src/locator/up.ts
@@ -22,21 +22,19 @@ type WalkStep = {
 };
 
 function startWalk(options: LocatorUpOptionsInput) : WalkStep {
-    const current = path.resolve(options.cwd ?? process.cwd());
-    const stopAt = options.stopAt ?
-        path.resolve(options.stopAt) :
+    const {
+        cwd,
+        stopAt,
+        ...baseOptions
+    } = options;
+    const current = path.resolve(cwd ?? process.cwd());
+    const ceiling = stopAt ?
+        path.resolve(current, stopAt) :
         path.parse(current).root;
-
-    const baseOptions: Omit<LocatorOptionsInput, 'cwd'> = {
-        ignore: options.ignore,
-        onlyFiles: options.onlyFiles,
-        onlyDirectories: options.onlyDirectories,
-        dot: options.dot,
-    };
 
     return {
         current,
-        stopAt,
+        stopAt: ceiling,
         baseOptions,
     };
 }

--- a/test/data/up/up.config.json
+++ b/test/data/up/up.config.json
@@ -1,0 +1,1 @@
+{ "from": "up.config.json" }

--- a/test/unit/locator-up.spec.ts
+++ b/test/unit/locator-up.spec.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { locateUp, locateUpSync } from '../../src';
+
+const basePath = path.join(import.meta.dirname, '..', 'data');
+const upBase = path.join(basePath, 'up');
+const deep = path.join(upBase, 'nested', 'deep');
+
+describe('src/locator/up.ts', () => {
+    it('should find a file at an ancestor directory', async () => {
+        const expectedPath = path.join(upBase, 'up.config.json');
+
+        const asyncResult = await locateUp('up.config.json', { cwd: deep });
+        expect(asyncResult).toBeDefined();
+        expect(asyncResult?.path).toEqual(expectedPath);
+
+        const syncResult = locateUpSync('up.config.json', { cwd: deep });
+        expect(syncResult).toBeDefined();
+        expect(syncResult?.path).toEqual(expectedPath);
+    });
+
+    it('should find a file at the starting directory', async () => {
+        const expectedPath = path.join(upBase, 'up.config.json');
+
+        const asyncResult = await locateUp('up.config.json', { cwd: upBase });
+        expect(asyncResult?.path).toEqual(expectedPath);
+
+        const syncResult = locateUpSync('up.config.json', { cwd: upBase });
+        expect(syncResult?.path).toEqual(expectedPath);
+    });
+
+    it('should return undefined when no ancestor matches before `stopAt`', async () => {
+        const asyncResult = await locateUp('up.config.json', {
+            cwd: deep,
+            stopAt: path.join(upBase, 'nested'),
+        });
+        expect(asyncResult).toBeUndefined();
+
+        const syncResult = locateUpSync('up.config.json', {
+            cwd: deep,
+            stopAt: path.join(upBase, 'nested'),
+        });
+        expect(syncResult).toBeUndefined();
+    });
+
+    it('should include `stopAt` in the search (inclusive ceiling)', async () => {
+        const expectedPath = path.join(upBase, 'up.config.json');
+
+        const asyncResult = await locateUp('up.config.json', { cwd: deep, stopAt: upBase });
+        expect(asyncResult?.path).toEqual(expectedPath);
+
+        const syncResult = locateUpSync('up.config.json', { cwd: deep, stopAt: upBase });
+        expect(syncResult?.path).toEqual(expectedPath);
+    });
+
+    it('should support brace patterns', async () => {
+        const expectedPath = path.join(upBase, 'up.config.json');
+
+        const asyncResult = await locateUp('up.config.{ts,json,yaml}', { cwd: deep, stopAt: upBase });
+        expect(asyncResult?.path).toEqual(expectedPath);
+
+        const syncResult = locateUpSync('up.config.{ts,json,yaml}', { cwd: deep, stopAt: upBase });
+        expect(syncResult?.path).toEqual(expectedPath);
+    });
+
+    it('should return undefined when nothing matches up to the root', async () => {
+        const asyncResult = await locateUp('definitely-not-here.json', { cwd: deep });
+        expect(asyncResult).toBeUndefined();
+
+        const syncResult = locateUpSync('definitely-not-here.json', { cwd: deep });
+        expect(syncResult).toBeUndefined();
+    });
+});

--- a/test/unit/locator-up.spec.ts
+++ b/test/unit/locator-up.spec.ts
@@ -77,4 +77,25 @@ describe('src/locator/up.ts', () => {
         const syncResult = locateUpSync('definitely-not-here.json', { cwd: deep });
         expect(syncResult).toBeUndefined();
     });
+
+    it('should resolve a relative `stopAt` against `cwd`, not process.cwd()', async () => {
+        const expectedPath = path.join(upBase, 'up.config.json');
+
+        // `stopAt: '../..'` from `cwd: deep` should resolve to `upBase` and let
+        // the walk find the file. The previous implementation resolved against
+        // process.cwd() instead, which would cap at an unrelated directory.
+        const asyncResult = await locateUp('up.config.json', { cwd: deep, stopAt: '../..' });
+        expect(asyncResult?.path).toEqual(expectedPath);
+
+        const syncResult = locateUpSync('up.config.json', { cwd: deep, stopAt: '../..' });
+        expect(syncResult?.path).toEqual(expectedPath);
+
+        // `stopAt: '..'` resolves to `upBase/nested` → cap before reaching
+        // `upBase` → no match. Confirms the resolution is relative to `cwd`.
+        const asyncCapped = await locateUp('up.config.json', { cwd: deep, stopAt: '..' });
+        expect(asyncCapped).toBeUndefined();
+
+        const syncCapped = locateUpSync('up.config.json', { cwd: deep, stopAt: '..' });
+        expect(syncCapped).toBeUndefined();
+    });
 });


### PR DESCRIPTION
## Summary

Adds `locateUp(pattern, { cwd, stopAt? })` and a `locateUpSync` variant. Walks from `cwd` toward the filesystem root and returns the first `LocatorInfo` that matches, or `undefined`. The `stopAt` ceiling is inclusive — the ceiling directory itself is still searched.

Closes #823.

## Why

Many CLIs need to find a config file by walking parent directories until a match is hit (\`tsconfig.json\`, \`.git\`, \`pnpm-workspace.yaml\`, \`eslint.config.*\`, …). Today, callers either pre-compute the ancestor list and pass it as \`cwd: string[]\` (which loses \"stop at the closest match\" ordering) or roll their own walk.

## Usage

\`\`\`typescript
import { locateUp } from 'locter';

const info = await locateUp('trapi.config.{ts,mts,cts,mjs,cjs,js,json}', {
    cwd: process.cwd(),
    stopAt: '/repo',   // optional ceiling, inclusive
});
// → { directory: '/repo', name: 'trapi.config', extension: '.ts', path: '/repo/trapi.config.ts' }
// or undefined if nothing matched
\`\`\`

## Design

- Reuses \`locate\` per ancestor, so \`pattern\` accepts the same \`string | string[]\` shape, and \`ignore\` / \`onlyFiles\` / \`onlyDirectories\` / \`dot\` pass through unchanged.
- \`cwd\` is constrained to a single \`string\` (multi-cwd doesn't make sense for an upward walk).
- \`stopAt\` is inclusive — easier to reason about than exclusive (\"walk up and INCLUDE the project root\" is the common ask).
- Walks stop when either \`current === stopAt\` or \`path.dirname(current) === current\` (filesystem root).

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run build\` (typecheck + bundle)
- [x] \`npm test\` (62 tests, 6 new in \`test/unit/locator-up.spec.ts\`)
- [x] Fixture: \`test/data/up/up.config.json\` + nested \`up/nested/deep/.keep\` for walk-from-deep scenarios