### PR TITLE
chore: v3 release prep — flat 6, YAMLLoader export, migration guide

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -253,6 +253,46 @@ try {
 }
 ```
 
+`LocterError` extends [`BaseError`](https://github.com/Tada5hi/ebec) from `@ebec/core`, so each instance also carries a `code` (auto-derived from the class name unless overridden — e.g. `'ENOENT'` for `LocterNotFoundError`s thrown by the JSON loader) and a `toJSON()` for structured logging.
+
+Each error class also publishes its `Symbol.for(...)` marker (`LOCTER_ERROR_MARKER`, `LOCTER_NOT_FOUND_ERROR_MARKER`, …), which makes `instanceof` work across realms — useful when consumers end up with duplicate copies of locter in their dependency tree.
+
+### Migrating from 2.x
+
+The 3.0 release reshapes a few public surfaces. The list below is exhaustive — no other public APIs changed.
+
+```diff
+- import { load, locate } from 'locter';
++ import { load, locate, LocterNotFoundError, LocterLoadError } from 'locter';
+
+  // 1. LocatorOptions.path → cwd
+- await locate('config.json', { path: process.cwd() });
++ await locate('config.json', { cwd: process.cwd() });
+
+  // 2. LocatorInfo.path now holds the FULL file path (it was the
+  //    containing directory in 2.x). Use .directory for the containing dir.
+- const filePath = path.join(info.path, info.name + info.extension);
++ const filePath = info.path;            // full file path
++ const dir      = info.directory;       // containing directory
+
+  // 3. load() / loadSync() (and every built-in loader) now throw
+  //    LocterError subclasses instead of generic Error / ebec BaseError.
+  try {
+      await load('config.json');
+- } catch (err) {
+-     if (err.message.includes('ENOENT')) { /* … */ }
++ } catch (err) {
++     if (err instanceof LocterNotFoundError) { /* … */ }
++     else if (err instanceof LocterLoadError) { /* parse error: err.cause */ }
++     else throw err;
+  }
+```
+
+Additionally:
+
+- The `ebec` runtime dependency is replaced by `@ebec/core`. If you used to import `BaseError` from `ebec`, switch to `@ebec/core`.
+- The package is now ESM-only (no `require('locter')`). This change shipped in the 2.x→3.x toolchain modernization commit; mentioned here for completeness.
+
 ### Runtime environments
 
 Locter ships with two runtime detection helpers:

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@ebec/core": "^1.1.0",
                 "destr": "^2.0.5",
                 "fast-glob": "^3.3.3",
-                "flat": "^5.0.2",
+                "flat": "^6.0.1",
                 "jiti": "^2.6.1",
                 "yaml": "^2.8.1"
             },
@@ -20,7 +20,6 @@
                 "@tada5hi/commitlint-config": "^1.3.1",
                 "@tada5hi/eslint-config": "^2.3.0",
                 "@tada5hi/tsconfig": "^0.7.2",
-                "@types/flat": "^5.0.2",
                 "@vitest/coverage-v8": "^4.1.5",
                 "eslint": "^10.3.0",
                 "husky": "^9.1.7",
@@ -1273,13 +1272,6 @@
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
             "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/flat": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/@types/flat/-/flat-5.0.5.tgz",
-            "integrity": "sha512-nPLljZQKSnac53KDUDzuzdRfGI0TDb5qPrb+SrQyN3MtdQrOnGsKniHN1iYZsJEBIVQve94Y6gNz22sgISZq+Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -2864,12 +2856,15 @@
             }
         },
         "node_modules/flat": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-            "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/flat/-/flat-6.0.1.tgz",
+            "integrity": "sha512-/3FfIa8mbrg3xE7+wAhWeV+bd7L2Mof+xtZb5dRDKZ+wDvYJK4WDYeIOuOhre5Yv5aQObZrlbRmk3RTSiuQBtw==",
             "license": "BSD-3-Clause",
             "bin": {
                 "flat": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/flat-cache": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
         "@tada5hi/commitlint-config": "^1.3.1",
         "@tada5hi/eslint-config": "^2.3.0",
         "@tada5hi/tsconfig": "^0.7.2",
-        "@types/flat": "^5.0.2",
         "@vitest/coverage-v8": "^4.1.5",
         "eslint": "^10.3.0",
         "husky": "^9.1.7",
@@ -70,7 +69,7 @@
         "@ebec/core": "^1.1.0",
         "destr": "^2.0.5",
         "fast-glob": "^3.3.3",
-        "flat": "^5.0.2",
+        "flat": "^6.0.1",
         "jiti": "^2.6.1",
         "yaml": "^2.8.1"
     }

--- a/src/loader/built-in/conf/module.ts
+++ b/src/loader/built-in/conf/module.ts
@@ -8,7 +8,7 @@
 // Based on https://github.com/unjs/rc9 (MIT)
 
 import { destr } from 'destr';
-import flat from 'flat';
+import { unflatten } from 'flat';
 import fs from 'node:fs';
 import { wrapLoaderError } from '../../../errors';
 import { buildFilePath } from '../../../locator';
@@ -69,6 +69,6 @@ export class ConfLoader implements Loader {
             config[key] = value;
         }
 
-        return flat.unflatten(config, { overwrite: true });
+        return unflatten(config, { overwrite: true });
     }
 }

--- a/src/loader/built-in/index.ts
+++ b/src/loader/built-in/index.ts
@@ -6,5 +6,6 @@
  */
 
 export * from './conf';
-export * from './module';
 export * from './json';
+export * from './module';
+export * from './yaml';


### PR DESCRIPTION
## Summary

Final polish ahead of cutting the 3.0 release.

### Commits

1. **\`fix(loader): export YAMLLoader from the public barrel\`** — \`YAMLLoader\` was documented in the README as a built-in loader but missing from \`src/loader/built-in/index.ts\`. Caught by a smoke-test of the built \`dist/\` against \`Object.keys\`.
2. **\`feat(deps)!: bump flat 5 → 6\`** — closes #830. flat@6 drops the default export and ships TS types, so \`ConfLoader\` now uses the named \`unflatten\` import and \`@types/flat\` is dropped from devDeps.
3. **\`docs: 2.x → 3.x migration guide + @ebec/core notes\`** — a concise diff-style migration block for the three renames + the \`Error → LocterError\` catch pattern, plus notes that \`LocterError\` extends \`@ebec/core\`'s \`BaseError\` (gets \`code\` and \`toJSON()\` for free) and that the \`LOCTER_*_MARKER\` constants are published for cross-realm \`instanceof\`.

Supersedes #830 (which only bumped the version without adapting the import).

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run build\` (typecheck + bundle, 21.14 kB)
- [x] \`npm test\` (70 tests still pass — ConfLoader's existing nested-key test exercises the new import)
- [x] Smoke test of built \`dist/\` on real Node 24 — verified \`YAMLLoader\` now exported, all 47 public symbols importable, JSON/YAML/Conf loaders + \`locateUp\` + \`loadPackageField\` + typed errors all work outside Vitest