### PR TITLE
docs: use buildFilePath in the 2.x migration example

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -270,10 +270,11 @@ The 3.0 release reshapes a few public surfaces. The list below is exhaustive —
 + await locate('config.json', { cwd: process.cwd() });
 
   // 2. LocatorInfo.path now holds the FULL file path (it was the
-  //    containing directory in 2.x). Use .directory for the containing dir.
-- const filePath = path.join(info.path, info.name + info.extension);
-+ const filePath = info.path;            // full file path
-+ const dir      = info.directory;       // containing directory
+  //    containing directory in 2.x). buildFilePath(info) still works in
+  //    both versions but is now a near-identity for LocatorInfo inputs.
+- const filePath = buildFilePath(info);  // 2.x: composed from .path + .name + .extension
++ const filePath = info.path;            // 3.x: just the path field
++ const dir      = info.directory;       // 3.x: containing directory (the old `info.path`)
 
   // 3. load() / loadSync() (and every built-in loader) now throw
   //    LocterError subclasses instead of generic Error / ebec BaseError.


### PR DESCRIPTION
The 2.x snippet shown in the new migration guide (\`path.join(info.path, info.name + info.extension)\`) was inaccurate — when \`info.extension\` was \`undefined\` it would emit \`"fileundefined"\`. The idiomatic 2.x path was \`buildFilePath(info)\`, which still works in 3.x but is now a near-identity for \`LocatorInfo\` inputs.

Caught in a self-audit of the v3 prep PR (#838).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the 2.x→3.x migration guide with clarified examples for path handling in the new version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/locter/pull/839?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->